### PR TITLE
SHA-1: fix P0 typecheck and scrollToMap

### DIFF
--- a/src/components/RunMap/ActivityChart.tsx
+++ b/src/components/RunMap/ActivityChart.tsx
@@ -17,6 +17,15 @@ interface YearlyRunDistanceData {
   total_distance_km: number
 }
 
+/** recharts@3 Tooltip formatter allows undefined values — keep the label stable. */
+function formatDistanceTooltip(label: string) {
+  return (value: number | string | ReadonlyArray<number | string> | undefined) => {
+    const numeric = Array.isArray(value) ? Number(value[0]) : Number(value)
+    const text = Number.isFinite(numeric) ? numeric.toFixed(2) : '0.00'
+    return [`${text} km`, label] as [string, string]
+  }
+}
+
 const ActivityChart: React.FC<ActivityChartProps> = ({ thisYear }) => {
   const [data, setData] = useState<MonthlyRunDistanceData[] | YearlyRunDistanceData[]>([])
   const [loading, setLoading] = useState(true)
@@ -159,7 +168,7 @@ const ActivityChart: React.FC<ActivityChartProps> = ({ thisYear }) => {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="year" name="年份" />
             <YAxis name="总跑量 (km)" unit=" km" />
-            <Tooltip formatter={(value: number) => [`${value.toFixed(2)} km`, '年跑量']} />
+            <Tooltip formatter={formatDistanceTooltip('年跑量')} />
             <Legend />
             <Bar dataKey="total_distance_km" fill="var(--color-svg-total-line)" name="年跑量 (km)" />
           </BarChart>
@@ -177,7 +186,7 @@ const ActivityChart: React.FC<ActivityChartProps> = ({ thisYear }) => {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="month" name="月份" />
             <YAxis name="跑量 (km)" unit=" km" />
-            <Tooltip formatter={(value: number) => [`${value.toFixed(2)} km`, '月跑量']} />
+            <Tooltip formatter={formatDistanceTooltip('月跑量')} />
             <Legend />
             <Bar dataKey="total_distance_km" fill="var(--color-svg-line)" name="月跑量 (km)" />
           </BarChart>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -220,7 +220,7 @@ function Index() {
               <YearsStat year={year} />
             )}
       </div>
-      <div className="w-full lg:w-2/3">
+      <div id="run-map" className="w-full lg:w-2/3">
         {year === 'Total'
           ? (
               <>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -80,23 +80,26 @@ function formatRunTime(moving_time: number): string {
   }
 }
 
+/** Stable scroll target for map / total-stat panel (must match id in pages/index). */
+export const RUN_MAP_SCROLL_TARGET_ID = 'run-map'
+
 let scrollTargetEl: HTMLElement | null = null
 
 function getScrollTargetEl(): HTMLElement | null {
   if (scrollTargetEl && scrollTargetEl.isConnected) {
     return scrollTargetEl
   }
-  scrollTargetEl = document.querySelector('.fl.w-100.w-70-l')
+  scrollTargetEl = document.getElementById(RUN_MAP_SCROLL_TARGET_ID)
   return scrollTargetEl
 }
 
-// for scroll to the map
+// Scroll the map (or total SVG) panel into view after year/city/run selection.
 function scrollToMap() {
   const el = getScrollTargetEl()
-  const rect = el?.getBoundingClientRect()
-  if (rect) {
-    window.scroll(rect.left + window.scrollX, rect.top + window.scrollY)
+  if (!el) {
+    return
   }
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
 function extractCities(str: string): string[] {


### PR DESCRIPTION
## Summary
Fixes the two P0 items from the code review on SHA-1.

1. **`typecheck` / `pnpm ci`** — `ActivityChart` Tooltip `formatter` was typed as `(value: number)` which no longer matches recharts@3 (`value` may be `undefined`). Shared `formatDistanceTooltip` handles that.
2. **`scrollToMap` no-op** — still queried removed Tachyons classes (`.fl.w-100.w-70-l`). Now targets `#run-map` on the main map/SVG column and uses `scrollIntoView`.

## Verification
- `pnpm run typecheck` ✅
- `pnpm run test:run` ✅ 38 tests
- `pnpm run build` ✅
- lint: only pre-existing P2 warnings on `index.tsx` effect setState